### PR TITLE
add a counter that can be used to track ignored scenarios, so that reports can be generated even when scenarios have been ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -395,4 +395,5 @@ FodyWeavers.xsd
 *.msp
 
 # JetBrains Rider
+.idea/
 *.sln.iml

--- a/Reports/CustomisableHtmlReportFormatter.cs
+++ b/Reports/CustomisableHtmlReportFormatter.cs
@@ -25,12 +25,12 @@ public class CustomisableHtmlReportFormatter : IReportFormatter
         if (Options.OnlyCreateReportOnFullySuccessfulTestRun)
         {
             if (scenariosRun.Any(x => x.Status == ExecutionStatus.Failed))
-                return; 
+                return;
         }
 
         if (Options.OnlyCreateReportOnFullTestRun)
         {
-            var numberOfTestsInRun = scenariosRun.Count;
+            var numberOfTestsInRun = scenariosRun.Count + IgnoredScenarios.Count;
             var totalNumberOfTests = Options.TestAssembly.CountNumberOfTestsInAssembly();
             if (numberOfTestsInRun != totalNumberOfTests)
                 return;
@@ -39,7 +39,7 @@ public class CustomisableHtmlReportFormatter : IReportFormatter
         WithCustomCss(Stylesheets.GetHideStyleSheet());
         WithCustomCss(Stylesheets.GetPlantUmlStyleSheet());
         WithCustomCss(Stylesheets.GetFilterFreeTextStyleSheet());
-        
+
         using var writer = new CustomisableHtmlResultTextWriter(stream, features)
         {
             Title = Options.Title,

--- a/Reports/IgnoredScenarios.cs
+++ b/Reports/IgnoredScenarios.cs
@@ -1,0 +1,14 @@
+﻿namespace LightBDD.Contrib.ReportingEnhancements.Reports;
+
+/// <summary>
+/// Use this to keep track of scenarios that are ignored using StepExecution.Current.IgnoreScenario().
+/// LightBDD doesn't include ignored scenarios when it calls IReportFormatter.Format().
+/// </summary>
+public abstract class IgnoredScenarios
+{
+    private static int _count = 0;
+
+    public static int Count => Interlocked.Add(ref _count, 0);
+
+    public static void Increment() => Interlocked.Increment(ref _count);
+}

--- a/Reports/IgnoredScenarios.cs
+++ b/Reports/IgnoredScenarios.cs
@@ -4,11 +4,11 @@
 /// Use this to keep track of scenarios that are ignored using StepExecution.Current.IgnoreScenario().
 /// LightBDD doesn't include ignored scenarios when it calls IReportFormatter.Format().
 /// </summary>
-public abstract class IgnoredScenarios
+public static class IgnoredScenarios
 {
     private static int _count = 0;
 
-    public static int Count => Interlocked.Add(ref _count, 0);
+    public static int Count => _count;
 
     public static void Increment() => Interlocked.Increment(ref _count);
 }

--- a/Reports/YamlReportFormatter.cs
+++ b/Reports/YamlReportFormatter.cs
@@ -31,7 +31,7 @@ public class YamlReportFormatter : IReportFormatter
 
         if (Options.OnlyCreateReportOnFullTestRun)
         {
-            var numberOfTestsInRun = scenariosRun.Count;
+            var numberOfTestsInRun = scenariosRun.Count + IgnoredScenarios.Count;
             var totalNumberOfTests = Options.TestAssembly.CountNumberOfTestsInAssembly();
             if (numberOfTestsInRun != totalNumberOfTests)
                 return;
@@ -55,9 +55,12 @@ public class YamlReportFormatter : IReportFormatter
 
         foreach (var feature in features)
         {
+            var scenarios = feature.GetScenarios().OrderBy(x => x.Info.Labels.Contains(HappyPathLabel)).ThenBy(x => x.Info.Name.ToString()).ToArray();
+            if (scenarios.Length == 0)
+                continue;
+
             yml.Append("  - Feature: " + feature.Info.Name.ToString().SanitiseForYml() + "\n");
             yml.Append("  - Scenarios:\n");
-            var scenarios = feature.GetScenarios().OrderBy(x => x.Info.Labels.Contains(HappyPathLabel)).ThenBy(x => x.Info.Name.ToString()).ToArray();
             foreach (var scenario in scenarios)
             {
                 yml.Append("    - Scenario: " + scenario.Info.Name.ToString().SanitiseForYml() + "\n");


### PR DESCRIPTION
Note that in YamlReportFormatter.cs the scenario header ("- Feature: <name>\n- Scenarios:\n") isn't output if the feature contains no scenarios (i.e. they're all ignored).  I can revert this change if necessary, but the YAML looked a bit odd with no scenarios under the feature.